### PR TITLE
Fix image paths in templates

### DIFF
--- a/templates/about-company.html
+++ b/templates/about-company.html
@@ -366,7 +366,7 @@
                                     </p>
                                     <div class="flex-three name">
                                         <span>--- Harriet Tubman</span>
-                                        <img src="./assets/images/testimonial/name.png" alt="image">
+                                        <img src="{{ url_for('static', filename='images/testimonial/name.png') }}" alt="image">
                                     </div>
                                     <div class="flex-three image-wrap">
                                         <ul class="image-list flex-three">
@@ -471,7 +471,7 @@
                                                 </div>
                                                 <div class="image relative">
                                                     <a href="team-details.html">
-                                                        <img src="./assets/images/team/team1.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/team/team1.jpg') }}" alt="image">
                                                     </a>
                                                     
                                                     <ul class="social-team flex-five">
@@ -502,7 +502,7 @@
                                                 </div>
                                                 <div class="image relative">
                                                     <a href="team-details.html">
-                                                        <img src="./assets/images/team/team2.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/team/team2.jpg') }}" alt="image">
                                                     </a>
                                                     <ul class="social-team flex-five">
                                                         <li>
@@ -532,7 +532,7 @@
                                                 </div>
                                                 <div class="image relative">
                                                     <a href="team-details.html">
-                                                        <img src="./assets/images/team/team3.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/team/team3.jpg') }}" alt="image">
                                                     </a>
                                                     <ul class="social-team flex-five">
                                                         <li>
@@ -562,7 +562,7 @@
                                                 </div>
                                                 <div class="image relative">
                                                    <a href="team-details.html"> 
-                                                    <img src="./assets/images/team/team4.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/team/team4.jpg') }}" alt="image">
                                                 </a>
                                                     <ul class="social-team flex-five">
                                                         <li>
@@ -592,7 +592,7 @@
                                                 </div>
                                                 <div class="image relative">
                                                     <a href="team-details.html">
-                                                        <img src="./assets/images/team/team5.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/team/team5.jpg') }}" alt="image">
                                                     </a>
                                                     <ul class="social-team flex-five">
                                                         <li>
@@ -622,7 +622,7 @@
                                                 </div>
                                                 <div class="image relative">
                                                     <a href="team-details.html">
-                                                        <img src="./assets/images/team/team6.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/team/team6.jpg') }}" alt="image">
                                                     </a>
                                                     <ul class="social-team flex-five">
                                                         <li>
@@ -652,7 +652,7 @@
                                                 </div>
                                                 <div class="image relative">
                                                    <a href="team-details.html">
-                                                    <img src="./assets/images/team/team7.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/team/team7.jpg') }}" alt="image">
                                                    </a>
                                                     <ul class="social-team flex-five">
                                                         <li>
@@ -682,7 +682,7 @@
                                                 </div>
                                                 <div class="image relative">
                                                     <a href="team-details.html">
-                                                        <img src="./assets/images/team/team8.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/team/team8.jpg') }}" alt="image">
                                                     </a>
                                                     <ul class="social-team flex-five">
                                                         <li>
@@ -764,7 +764,7 @@
                         <div class="row">
                             <div class="col-lg-12">
                                 <div class="video-about">
-                                    <img src="./assets/images/page/video-about.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/video-about.jpg') }}" alt="image">
                                     <div class="btn-video video-wrap">
                                         <a href="https://www.youtube.com/watch?v=rrtbyoYx8J4" class="tf-video flex-five widget-videos">
                                             <i class="icon-Play"></i>
@@ -797,7 +797,7 @@
                                             <div class="swiper-slide">
                                                 <div class="testimonial-style3 style3-h5 flex-three">
                                                     <div class="image">
-                                                        <img src="./assets/images/testimonial/avt.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/testimonial/avt.jpg') }}" alt="image">
                                                     </div>
                                                     <div class="content">
                                                         <p class="des">Climb the mountain not to plant your flag but to
@@ -827,7 +827,7 @@
                                             <div class="swiper-slide">
                                                 <div class="testimonial-style3 style3-h5 flex-three">
                                                     <div class="image">
-                                                        <img src="./assets/images/testimonial/avt.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/testimonial/avt.jpg') }}" alt="image">
                                                     </div>
                                                     <div class="content">
                                                         <p class="des">Climb the mountain not to plant your flag but to
@@ -857,7 +857,7 @@
                                             <div class="swiper-slide">
                                                 <div class="testimonial-style3 style3-h5 flex-three">
                                                     <div class="image">
-                                                        <img src="./assets/images/testimonial/avt.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/testimonial/avt.jpg') }}" alt="image">
                                                     </div>
                                                     <div class="content">
                                                         <p class="des">Climb the mountain not to plant your flag but to
@@ -911,27 +911,27 @@
                                     <div class="swiper-wrapper">
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br1.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br1.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br2.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br2.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br3.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br3.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br4.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br4.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br5.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br5.png') }}" alt="image">
                                             </div>
                                         </div>
                                     </div>
@@ -942,27 +942,27 @@
                                     <div class="swiper-wrapper">
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br6.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br6.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br7.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br7.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br9.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br9.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br10.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br10.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br8.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br8.png') }}" alt="image">
                                             </div>
                                         </div>
                                     </div>

--- a/templates/blog-details.html
+++ b/templates/blog-details.html
@@ -252,7 +252,7 @@
                                           ad minima veniam, quis nostrum exercitationem ullam corporis 
                                           suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur
                                     </p>
-                                    <img src="./assets/images/blog/blog-details.jpg" alt="Image blog" class="mb-30">
+                                    <img src="{{ url_for('static', filename='images/blog/blog-details.jpg') }}" alt="Image blog" class="mb-30">
                                     <p class="description mb-40">Nemo enim ipsam voluptatem quia voluptas sit 
                                         aspernatur aut odit aut fugit, sed quia consequuntur magni dolores 
                                         eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est,
@@ -274,7 +274,7 @@
                                     <p class="description mb-50">
                                         No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful. Nor again is there anyone who loves or pursues or desires to obtain pain of itself because it is painse
                                     </p>
-                                    <img src="./assets/images/blog/blog-details2.jpg" alt="Image blog" class="mb-30">
+                                    <img src="{{ url_for('static', filename='images/blog/blog-details2.jpg') }}" alt="Image blog" class="mb-30">
                                     <h3 class="entry-title mb-15">
                                         Conference For New Design
                                     </h3>
@@ -345,7 +345,7 @@
                                 <div class="post-blog flex-two mb-80">
                                     <div class="post-blog-item flex-three">
                                         <div class="image-post left">
-                                            <img src="./assets/images/blog/bl-2.jpg" alt="">
+                                            <img src="{{ url_for('static', filename='images/blog/bl-2.jpg') }}" alt="">
                                         </div>
                                         <div class="content-post">
                                             <span class="date color-text font-man">October 25, 2025</span>
@@ -358,7 +358,7 @@
                                             <h5 class="title"><a href="#">Delving into the Aesthetics and Functionality of Our Design</a></h5>                                           
                                         </div>
                                         <div class="image-post right">
-                                            <img src="./assets/images/blog/bl-1.jpg" alt="">
+                                            <img src="{{ url_for('static', filename='images/blog/bl-1.jpg') }}" alt="">
                                         </div>
                 
                                     </div>
@@ -485,7 +485,7 @@
                                         <div class="widget-recent-post">
                                             <div class="recent-post-item flex-three mb-30">
                                                 <a href="#" class="image">
-                                                    <img src="./assets/images/blog/recent1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/blog/recent1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <span class="date font-man">October 25, 2025</span>
@@ -494,7 +494,7 @@
                                             </div>
                                             <div class="recent-post-item flex-three mb-30">
                                                 <a href="#" class="image">
-                                                    <img src="./assets/images/blog/recent2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/blog/recent2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <span class="date font-man">October 25, 2025</span>
@@ -503,7 +503,7 @@
                                             </div>
                                             <div class="recent-post-item flex-three">
                                                 <a href="#" class="image">
-                                                    <img src="./assets/images/blog/recent3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/blog/recent3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <span class="date font-man">October 25, 2025</span>

--- a/templates/blog-style2.html
+++ b/templates/blog-style2.html
@@ -235,7 +235,7 @@
                                 <article class="side-blog mb-50 relative">
                                     <div class="blog-image overflow-hiden">
                                         <a class="post-thumbnail" href="blog-details.html">
-                                            <img src="./assets/images/blog/blog1.jpg" alt="Image blog">
+                                            <img src="{{ url_for('static', filename='images/blog/blog1.jpg') }}" alt="Image blog">
                                         </a>
                                     </div>
                                     <div class="blog-content content-grid">
@@ -275,7 +275,7 @@
                                 <article class="side-blog mb-50 relative">
                                     <div class="blog-image overflow-hiden">
                                         <a class="post-thumbnail" href="blog-details.html">
-                                            <img src="./assets/images/blog/blog2.jpg" alt="Image blog">
+                                            <img src="{{ url_for('static', filename='images/blog/blog2.jpg') }}" alt="Image blog">
                                         </a>
                                     </div>
                                     <div class="blog-content content-grid">
@@ -315,7 +315,7 @@
                                 <article class="side-blog mb-70 relative">
                                     <div class="blog-image overflow-hiden">
                                         <a class="post-thumbnail" href="blog-details.html">
-                                            <img src="./assets/images/blog/blog3.jpg" alt="Image blog">
+                                            <img src="{{ url_for('static', filename='images/blog/blog3.jpg') }}" alt="Image blog">
                                         </a>
                                     </div>
                                     <div class="blog-content content-grid">
@@ -388,7 +388,7 @@
                                         <div class="widget-recent-post">
                                             <div class="recent-post-item flex-three mb-30">
                                                 <a href="#" class="image">
-                                                    <img src="./assets/images/blog/recent1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/blog/recent1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <span class="date font-man">October 25, 2025</span>
@@ -397,7 +397,7 @@
                                             </div>
                                             <div class="recent-post-item flex-three mb-30">
                                                 <a href="#" class="image">
-                                                    <img src="./assets/images/blog/recent2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/blog/recent2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <span class="date font-man">October 25, 2025</span>
@@ -406,7 +406,7 @@
                                             </div>
                                             <div class="recent-post-item flex-three">
                                                 <a href="#" class="image">
-                                                    <img src="./assets/images/blog/recent3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/blog/recent3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <span class="date font-man">October 25, 2025</span>

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -236,7 +236,7 @@
                                 <article class="side-blog mb-70 relative">
                                     <div class="blog-image overflow-hiden">
                                         <a class="post-thumbnail" href="blog-details.html">
-                                            <img src="./assets/images/blog/blog4.jpg" alt="Image blog">
+                                            <img src="{{ url_for('static', filename='images/blog/blog4.jpg') }}" alt="Image blog">
                                         </a>
                                     </div>
                                     <div class="blog-content content-list">
@@ -264,7 +264,7 @@
                                 <article class="side-blog mb-70 relative">
                                     <div class="blog-image overflow-hiden">
                                         <a class="post-thumbnail" href="blog-details.html">
-                                            <img src="./assets/images/blog/blog5.jpg" alt="Image blog">
+                                            <img src="{{ url_for('static', filename='images/blog/blog5.jpg') }}" alt="Image blog">
                                         </a>
                                     </div>
                                     <div class="blog-content content-list">
@@ -292,7 +292,7 @@
                                 <article class="side-blog mb-70 relative">
                                     <div class="blog-image overflow-hiden">
                                         <a class="post-thumbnail" href="blog-details.html">
-                                            <img src="./assets/images/blog/blog6.jpg" alt="Image blog">
+                                            <img src="{{ url_for('static', filename='images/blog/blog6.jpg') }}" alt="Image blog">
                                         </a>
                                     </div>
                                     <div class="blog-content content-list">
@@ -320,7 +320,7 @@
                                 <article class="side-blog mb-70 relative">
                                     <div class="blog-image overflow-hiden">
                                         <a class="post-thumbnail" href="blog-details.html">
-                                            <img src="./assets/images/blog/blog7.jpg" alt="Image blog">
+                                            <img src="{{ url_for('static', filename='images/blog/blog7.jpg') }}" alt="Image blog">
                                         </a>
                                     </div>
                                     <div class="blog-content content-list">
@@ -348,7 +348,7 @@
                                 <article class="side-blog mb-70 relative">
                                     <div class="blog-image overflow-hiden">
                                         <a class="post-thumbnail" href="blog-details.html">
-                                            <img src="./assets/images/blog/blog8.jpg" alt="Image blog">
+                                            <img src="{{ url_for('static', filename='images/blog/blog8.jpg') }}" alt="Image blog">
                                         </a>
                                     </div>
                                     <div class="blog-content content-list">
@@ -376,7 +376,7 @@
                                 <article class="side-blog mb-70 relative">
                                     <div class="blog-image overflow-hiden">
                                         <a class="post-thumbnail" href="blog-details.html">
-                                            <img src="./assets/images/blog/blog9.jpg" alt="Image blog">
+                                            <img src="{{ url_for('static', filename='images/blog/blog9.jpg') }}" alt="Image blog">
                                         </a>
                                     </div>
                                     <div class="blog-content content-list">
@@ -404,7 +404,7 @@
                                 <article class="side-blog mb-70 relative">
                                     <div class="blog-image overflow-hiden">
                                         <a class="post-thumbnail" href="blog-details.html">
-                                            <img src="./assets/images/blog/blog10.jpg" alt="Image blog">
+                                            <img src="{{ url_for('static', filename='images/blog/blog10.jpg') }}" alt="Image blog">
                                         </a>
                                     </div>
                                     <div class="blog-content content-list">
@@ -432,7 +432,7 @@
                                 <article class="side-blog mb-70 relative">
                                     <div class="blog-image overflow-hiden">
                                         <a class="post-thumbnail" href="blog-details.html">
-                                            <img src="./assets/images/blog/blog11.jpg" alt="Image blog">
+                                            <img src="{{ url_for('static', filename='images/blog/blog11.jpg') }}" alt="Image blog">
                                         </a>
                                     </div>
                                     <div class="blog-content content-list">
@@ -460,7 +460,7 @@
                                 <article class="side-blog mb-70 relative">
                                     <div class="blog-image overflow-hiden">
                                         <a class="post-thumbnail" href="blog-details.html">
-                                            <img src="./assets/images/blog/blog12.jpg" alt="Image blog">
+                                            <img src="{{ url_for('static', filename='images/blog/blog12.jpg') }}" alt="Image blog">
                                         </a>
                                     </div>
                                     <div class="blog-content content-list">

--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -304,7 +304,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <img src="./assets/images/page/contact.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/contact.jpg') }}" alt="image">
 
                                 </div>
                                

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -769,7 +769,7 @@
                         <div class="row">
                             <div class="col-md-12">
                                 <div class="video-faq relative">
-                                    <img src="./assets/images/page/video-faq.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/video-faq.jpg') }}" alt="image">
                                     <div class="btn-video video-wrap">
                                         <a href="https://www.youtube.com/watch?v=rrtbyoYx8J4" class="tf-video flex-five widget-videos">
                                             <i class="icon-Play"></i>

--- a/templates/home2.html
+++ b/templates/home2.html
@@ -238,11 +238,11 @@
                                 </div>
                                 <div class="col-md-6">
                                     <div class="image relative">
-                                        <img src="./assets/images/page/banner2.png" alt="image" class="shape" >
-                                        <img src="./assets/images/page/shape-h21.png" alt="image" class="shape1">
-                                        <img src="./assets/images/page/shape-h22.png" alt="image" class="shape2">
-                                        <img src="./assets/images/page/shape-h23.png" alt="image" class="shape3">
-                                        <img src="./assets/images/page/shape-h24.png" alt="image" class="shape4">
+                                        <img src="{{ url_for('static', filename='images/page/banner2.png') }}" alt="image" class="shape" >
+                                        <img src="{{ url_for('static', filename='images/page/shape-h21.png') }}" alt="image" class="shape1">
+                                        <img src="{{ url_for('static', filename='images/page/shape-h22.png') }}" alt="image" class="shape2">
+                                        <img src="{{ url_for('static', filename='images/page/shape-h23.png') }}" alt="image" class="shape3">
+                                        <img src="{{ url_for('static', filename='images/page/shape-h24.png') }}" alt="image" class="shape4">
                                     </div>
                                 </div>
                             </div>
@@ -407,7 +407,7 @@
                                     </p>
                                     <div class="flex-three name wow fadeInUpSmall" data-wow-delay=".3s">
                                         <span>--- Harriet Tubman</span>
-                                        <img src="./assets/images/testimonial/name.png" alt="image">
+                                        <img src="{{ url_for('static', filename='images/testimonial/name.png') }}" alt="image">
                                     </div>
                                     <div class="flex-three image-wrap ">
                                         <ul class="image-list flex-three wow fadeInUpSmall" data-wow-delay=".4s">
@@ -574,12 +574,12 @@
                             </div>
                             <div class="col-lg-6">
                                 <div class="image relative">
-                                    <img src="./assets/images/page/company1.png" alt="image" class="company1">
-                                    <img src="./assets/images/page/company2.png" alt="image" class="company2">
-                                    <img src="./assets/images/page/company3.png" alt="image" class="company3">
-                                    <img src="./assets/images/page/company4.png" alt="image" class="company4">
-                                    <img src="./assets/images/page/company5.png" alt="image" class="company5">
-                                    <img src="./assets/images/page/company6.png" alt="image" class="company6">
+                                    <img src="{{ url_for('static', filename='images/page/company1.png') }}" alt="image" class="company1">
+                                    <img src="{{ url_for('static', filename='images/page/company2.png') }}" alt="image" class="company2">
+                                    <img src="{{ url_for('static', filename='images/page/company3.png') }}" alt="image" class="company3">
+                                    <img src="{{ url_for('static', filename='images/page/company4.png') }}" alt="image" class="company4">
+                                    <img src="{{ url_for('static', filename='images/page/company5.png') }}" alt="image" class="company5">
+                                    <img src="{{ url_for('static', filename='images/page/company6.png') }}" alt="image" class="company6">
                                 </div>
 
                             </div>
@@ -605,7 +605,7 @@
                                 <div class="team-grid-4">
                                     <div class="tf-team-style2 flex wow fadeInUpSmall" data-wow-delay=".2s">
                                         <div class="image">
-                                            <img src="./assets/images/team/team-h21.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/team-h21.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <h3 class="title"><a href="team-details.html">Robert R. Simmons</a></h3>
@@ -629,7 +629,7 @@
                                     </div>
                                     <div class="tf-team-style2 flex wow fadeInUpSmall" data-wow-delay=".3s">
                                         <div class="image">
-                                            <img src="./assets/images/team/teamh22.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/teamh22.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <h3 class="title"><a href="team-details.html">Laverne M. Kellems</a></h3>
@@ -653,7 +653,7 @@
                                     </div>
                                     <div class="tf-team-style2 flex wow fadeInUpSmall" data-wow-delay=".3s">
                                         <div class="image">
-                                            <img src="./assets/images/team/teamh23.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/teamh23.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <h3 class="title"><a href="team-details.html">Jermaine P. Elkins</a></h3>
@@ -677,7 +677,7 @@
                                     </div>
                                     <div class="tf-team-style2 flex wow fadeInUpSmall" data-wow-delay=".4s">
                                         <div class="image">
-                                            <img src="./assets/images/team/teamh24.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/teamh24.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <h3 class="title"><a href="team-details.html">David R. Robinson</a></h3>
@@ -713,7 +713,7 @@
                             <div class="col-sm-12 col-md-6 col-xl-3 ">
                                 <div class="tf-case">
                                     <div class="image-case">
-                                        <img src="./assets/images/image-box/case-h21.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/image-box/case-h21.jpg') }}" alt="image">
                                     </div>
                                     <div class="content-case">
                                         <span class="category">Cyber Security</span>
@@ -730,7 +730,7 @@
                             <div class="col-sm-12 col-md-6 col-xl-3 ">
                                 <div class="tf-case">
                                     <div class="image-case">
-                                        <img src="./assets/images/image-box/case-h22.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/image-box/case-h22.jpg') }}" alt="image">
                                     </div>
                                     <div class="content-case">
                                         <span class="category">IT Consulting</span>
@@ -747,7 +747,7 @@
                             <div class="col-sm-12 col-md-6 col-xl-3 ">
                                 <div class="tf-case">
                                     <div class="image-case">
-                                        <img src="./assets/images/image-box/case-h23.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/image-box/case-h23.jpg') }}" alt="image">
                                     </div>
                                     <div class="content-case">
                                         <span class="category">Data Security</span>
@@ -764,7 +764,7 @@
                             <div class="col-sm-12 col-md-6 col-xl-3 ">
                                 <div class="tf-case">
                                     <div class="image-case">
-                                        <img src="./assets/images/image-box/case-h24.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/image-box/case-h24.jpg') }}" alt="image">
                                     </div>
                                     <div class="content-case">
                                         <span class="category">Product Design</span>
@@ -791,11 +791,11 @@
                         <div class="row">
                             <div class="col-lg-6">
                                 <div class="image-wc-us relative">
-                                    <img src="./assets/images/page/wcus1.png" alt="image" class="wcus-1">
-                                    <img src="./assets/images/page/wcus2.png" alt="image" class="wcus-2">
-                                    <img src="./assets/images/page/wcus3.png" alt="image" class="wcus-3">
-                                    <img src="./assets/images/page/wcus4.png" alt="image" class="wcus-4">
-                                    <img src="./assets/images/page/wcus5.png" alt="image" class="wcus-5">
+                                    <img src="{{ url_for('static', filename='images/page/wcus1.png') }}" alt="image" class="wcus-1">
+                                    <img src="{{ url_for('static', filename='images/page/wcus2.png') }}" alt="image" class="wcus-2">
+                                    <img src="{{ url_for('static', filename='images/page/wcus3.png') }}" alt="image" class="wcus-3">
+                                    <img src="{{ url_for('static', filename='images/page/wcus4.png') }}" alt="image" class="wcus-4">
+                                    <img src="{{ url_for('static', filename='images/page/wcus5.png') }}" alt="image" class="wcus-5">
                                 </div>
 
                             </div>
@@ -910,7 +910,7 @@
                                                     your business
                                                 </p>
                                                 <div class="flex-two testimonial-bottom">
-                                                    <img src="./assets/images/brand/dropbox-white.png" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/brand/dropbox-white.png') }}" alt="image">
                                                     <div class="review">
                                                         <i class="icon-start"></i>
                                                         <i class="icon-start"></i>
@@ -941,7 +941,7 @@
                                                     can see the world, not so the world can see you
                                                 </p>
                                                 <div class="flex-two testimonial-bottom">
-                                                    <img src="./assets/images/brand/linktree.png" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/brand/linktree.png') }}" alt="image">
                                                     <div class="review">
                                                         <i class="icon-start"></i>
                                                         <i class="icon-start"></i>
@@ -973,7 +973,7 @@
                                                     your business
                                                 </p>
                                                 <div class="flex-two testimonial-bottom">
-                                                    <img src="./assets/images/brand/dropbox-white.png" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/brand/dropbox-white.png') }}" alt="image">
                                                     <div class="review">
                                                         <i class="icon-start"></i>
                                                         <i class="icon-start"></i>
@@ -1004,7 +1004,7 @@
                                                     can see the world, not so the world can see you
                                                 </p>
                                                 <div class="flex-two testimonial-bottom">
-                                                    <img src="./assets/images/brand/linktree.png" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/brand/linktree.png') }}" alt="image">
                                                     <div class="review">
                                                         <i class="icon-start"></i>
                                                         <i class="icon-start"></i>
@@ -1126,7 +1126,7 @@
                                     <div class="col-md-6 wow fadeInUpSmall" data-wow-delay=".3s">
                                         <div class="tf-blog-style1 relative">
                                             <a href="blog-details.html" class="image overflow-hiden relative">
-                                                <img src="./assets/images/blog/blog-h2.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/blog/blog-h2.jpg') }}" alt="image">
                                             </a>
                                             <div class="content style2">
                                                 <span class="date text-white font-man">October 25, 2025</span>
@@ -1203,27 +1203,27 @@
                                     <div class="swiper-wrapper">
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br1.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br1.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br2.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br2.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br3.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br3.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br4.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br4.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br5.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br5.png') }}" alt="image">
                                             </div>
                                         </div>
                                     </div>
@@ -1234,27 +1234,27 @@
                                     <div class="swiper-wrapper">
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br6.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br6.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br7.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br7.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br9.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br9.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br10.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br10.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br8.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br8.png') }}" alt="image">
                                             </div>
                                         </div>
                                     </div>

--- a/templates/home3.html
+++ b/templates/home3.html
@@ -219,7 +219,7 @@
             <main id="main">
                 <!--  Main Slider -->
                 <section class="banner-home3 bg-3 relative">
-                    <img src="./assets/images/page/mask-banner3.png" alt="image" class="mask-banner3">
+                    <img src="{{ url_for('static', filename='images/page/mask-banner3.png') }}" alt="image" class="mask-banner3">
                     <div class="tf-container">
                         <div class="row z-index-3 relative">
                             <div class="col-lg-6">
@@ -245,7 +245,7 @@
                             </div>
                             <div class="col-lg-6">
                                 <div class="image layer">
-                                    <img src="./assets/images/page/banner-h3.png" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/banner-h3.png') }}" alt="image">
                                 </div>
                             </div>
                         </div>
@@ -375,7 +375,7 @@
 
                 <!--  Optimize Solutions -->
                 <section class="optimize-olutions bg-3 relative overflow-hiden">
-                    <img src="./assets/images/page/mask-banner3.png" alt="image" class="mask-banner3">
+                    <img src="{{ url_for('static', filename='images/page/mask-banner3.png') }}" alt="image" class="mask-banner3">
                     <div class="tf-container">
                         <div class="row relative z-index-3 mb-60">
                             <div class="col-md-7">
@@ -415,7 +415,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".2s">
                                 <div class="tf-image-box2">
                                     <a href="#" class="image">
-                                        <img src="./assets/images/image-box/os-h31.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/image-box/os-h31.jpg') }}" alt="image">
                                     </a>
                                     <div class="content">
                                         <span class="category">Startup Business</span>
@@ -436,7 +436,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".3s">
                                 <div class="tf-image-box2">
                                     <a href="#" class="image">
-                                        <img src="./assets/images/image-box/os-h32.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/image-box/os-h32.jpg') }}" alt="image">
                                     </a>
                                     <div class="content">
                                         <span class="category">Small Business</span>
@@ -457,7 +457,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".4s" >
                                 <div class="tf-image-box2">
                                     <a href="#" class="image">
-                                        <img src="./assets/images/image-box/os-h33.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/image-box/os-h33.jpg') }}" alt="image">
                                     </a>
                                     <div class="content">
                                         <div class="category">Entrepreneur</div>
@@ -522,7 +522,7 @@
                             </div>
                             <div class="col-lg-4">
                                 <div class="service-image-h3 layer">
-                                    <img src="./assets/images/page/serviceh3.png" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/serviceh3.png') }}" alt="image">
                                 </div>
 
                             </div>
@@ -639,7 +639,7 @@
                             </div>
                             <div class="col-lg-6">
                                 <div class="feature-h3-image relative">
-                                    <img src="./assets/images/page/feature-h3.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/feature-h3.jpg') }}" alt="image">
                                     <div class="counting-feature bg-8">
                                         <div class="progress-box2 flex-three">
                                             <div class="progress-skill">
@@ -699,7 +699,7 @@
                             <div class="col-12 col-sm-6 col-lg-3 wow fadeInUpSmall" data-wow-delay=".2s">
                                 <div class="tf-team-style3 hover-social">
                                     <div class="image">
-                                        <img src="./assets/images/team/team-h31.png" alt="image">
+                                        <img src="{{ url_for('static', filename='images/team/team-h31.png') }}" alt="image">
                                     </div>
                                     <div class="content center">
                                         <h3 class="title"><a href="team-details.html">Rocco J. Martin</a></h3>
@@ -725,7 +725,7 @@
                             <div class="col-12 col-sm-6 col-lg-3 wow fadeInUpSmall" data-wow-delay=".3s">
                                 <div class="tf-team-style3 hover-social">
                                     <div class="image">
-                                        <img src="./assets/images/team/team-h32.png" alt="image">
+                                        <img src="{{ url_for('static', filename='images/team/team-h32.png') }}" alt="image">
                                     </div>
                                     <div class="content center">
                                         <h3 class="title"><a href="team-details.html">Galen B. Woodhouse</a></h3>
@@ -751,7 +751,7 @@
                             <div class="col-12 col-sm-6 col-lg-3 wow fadeInUpSmall" data-wow-delay=".4s" >
                                 <div class="tf-team-style3 hover-social">
                                     <div class="image">
-                                        <img src="./assets/images/team/team-h33.png" alt="image">
+                                        <img src="{{ url_for('static', filename='images/team/team-h33.png') }}" alt="image">
                                     </div>
                                     <div class="content center">
                                         <h3 class="title"><a href="team-details.html">Brandon K. Bishop</a></h3>
@@ -777,7 +777,7 @@
                             <div class="col-12 col-sm-6 col-lg-3 wow fadeInUpSmall" data-wow-delay=".5s">
                                 <div class="tf-team-style3 hover-social">
                                     <div class="image">
-                                        <img src="./assets/images/team/team-h34.png" alt="image">
+                                        <img src="{{ url_for('static', filename='images/team/team-h34.png') }}" alt="image">
                                     </div>
                                     <div class="content center">
                                         <h3 class="title"><a href="team-details.html">Donald A. Thompson</a></h3>
@@ -850,7 +850,7 @@
                             </div>
                             <div class="col-md-7">
                                 <div class="process-image-wrap layer">
-                                    <img src="./assets/images/page/Illustration-h3.png" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/Illustration-h3.png') }}" alt="image">
 
                                 </div>
                             </div>
@@ -866,8 +866,8 @@
                             <div class="col-lg-6">
                                 <div class="image-wrapper-wcus3 relative">
                                     <div class="image-wcus3 flex">
-                                        <img src="./assets/images/page/wcus-h3.jpg" alt="imge" class="wcus-pt wow fadeInUpSmall" data-wow-delay=".2s">
-                                        <img src="./assets/images/page/wcus-h31.jpg" alt="imge " class="wow fadeInUpSmall" data-wow-delay=".3s">
+                                        <img src="{{ url_for('static', filename='images/page/wcus-h3.jpg') }}" alt="imge" class="wcus-pt wow fadeInUpSmall" data-wow-delay=".2s">
+                                        <img src="{{ url_for('static', filename='images/page/wcus-h31.jpg') }}" alt="imge " class="wow fadeInUpSmall" data-wow-delay=".3s">
                                     </div>
                                     <div class="quote-wcus-3 flex bg-8">
                                         <div class="icon">
@@ -992,7 +992,7 @@
 
                 <!-- Pricing-->
                 <section class="section-pricing pt-122 pb-130 overflow-hiden relative bg-3">
-                    <img src="./assets/images/page/mask-banner3.png" alt="image" class="mask-banner3">
+                    <img src="{{ url_for('static', filename='images/page/mask-banner3.png') }}" alt="image" class="mask-banner3">
                     <div class="tf-container">
                         <div class="row relative z-index-3">
                             <div class="col-lg-12">
@@ -1125,7 +1125,7 @@
                         <div class="row">
                             <div class="col-md-5">
                                 <div class="testimonial-h3-image relative">
-                                    <img src="./assets/images/testimonial/tes-h3.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/testimonial/tes-h3.jpg') }}" alt="image">
                                     <div class="testimonial-avt-box relative bg-8">
                                         <p>5m+ Trusted Global Clients</p>
                                         <div class="icon">
@@ -1182,7 +1182,7 @@
                                                         see the world, not so the world can see you.
                                                     </p>
                                                     <div class="testimonial-bottom flex-two">
-                                                        <img src="./assets/images/brand/linktree-black.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/linktree-black.png') }}" alt="image">
                                                         <div class="review">
                                                             <i class="icon-start"></i>
                                                             <i class="icon-start"></i>
@@ -1206,7 +1206,7 @@
                                                         see the world, not so the world can see you.
                                                     </p>
                                                     <div class="testimonial-bottom flex-two">
-                                                        <img src="./assets/images/brand/linktree-black.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/linktree-black.png') }}" alt="image">
                                                         <div class="review">
                                                             <i class="icon-start"></i>
                                                             <i class="icon-start"></i>
@@ -1230,7 +1230,7 @@
                                                         see the world, not so the world can see you.
                                                     </p>
                                                     <div class="testimonial-bottom flex-two">
-                                                        <img src="./assets/images/brand/linktree-black.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/linktree-black.png') }}" alt="image">
                                                         <div class="review">
                                                             <i class="icon-start"></i>
                                                             <i class="icon-start"></i>
@@ -1274,7 +1274,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".2s">
                                 <div class="tf-blog-style3 pd-5 bg-sd">
                                     <a href="blog-details.html" class="image">
-                                        <img src="./assets/images/blog/blog-h3.jpg" alt="">
+                                        <img src="{{ url_for('static', filename='images/blog/blog-h3.jpg') }}" alt="">
                                     </a>
                                     <div class="content style1">
                                         <span class="date font-man">October 25, 2025</span>
@@ -1290,7 +1290,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".3s">
                                 <div class="tf-blog-style3 pd-5 bg-sd">
                                     <a href="blog-details.html" class="image">
-                                        <img src="./assets/images/blog/blog-h31.jpg" alt="">
+                                        <img src="{{ url_for('static', filename='images/blog/blog-h31.jpg') }}" alt="">
                                     </a>
                                     <div class="content style1">
                                         <span class="date font-man">October 25, 2025</span>
@@ -1306,7 +1306,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".4s" >
                                 <div class="tf-blog-style3 pd-5 bg-sd">
                                     <a href="blog-details.html" class="image">
-                                        <img src="./assets/images/blog/blog-h32.jpg" alt="">
+                                        <img src="{{ url_for('static', filename='images/blog/blog-h32.jpg') }}" alt="">
                                     </a>
                                     <div class="content style1">
                                         <span class="date font-man">October 25, 2025</span>
@@ -1328,12 +1328,12 @@
             </main>
 
             <footer id="footer" class="footer-style-3 bg-3 overflow-hiden relative">
-                <img src="./assets/images/page/mask-banner3.png" alt="image" class="mask-banner3">
+                <img src="{{ url_for('static', filename='images/page/mask-banner3.png') }}" alt="image" class="mask-banner3">
                 <div class="tf-container">
                     <div class="row z-index-3 relative">
                         <div class="col-12 col-sm-6 col-lg-3">
                             <div class="logo-footer">
-                                <img src="./assets/images/logo-footer2.png" alt="image" class="logo">
+                                <img src="{{ url_for('static', filename='images/logo-footer2.png') }}" alt="image" class="logo">
                                 <p class="des">IT professionals, we work closely with
                                     you to understand your objectives and challenges, and develop tailor</p>
                                     <form action="/" class="form-footer3 relative flex" id="subscribe-form" method="post" accept-charset="utf-8" data-mailchimp="true">

--- a/templates/home4.html
+++ b/templates/home4.html
@@ -194,11 +194,11 @@
                             </div>
                             <div class="col-md-6">
                                 <div class="image relative">
-                                    <img src="./assets/images/page/mask-home4.png" alt="image" class="image1">
-                                    <img src="./assets/images/page/tag.png" alt="image" class="image2">
-                                    <img src="./assets/images/page/html-5.png" alt="image" class="image3">
-                                    <img src="./assets/images/page/mask-home4.jpg" alt="image" class="image4">
-                                    <img src="./assets/images/page/cycle-mask.png" alt="image" class="image5">
+                                    <img src="{{ url_for('static', filename='images/page/mask-home4.png') }}" alt="image" class="image1">
+                                    <img src="{{ url_for('static', filename='images/page/tag.png') }}" alt="image" class="image2">
+                                    <img src="{{ url_for('static', filename='images/page/html-5.png') }}" alt="image" class="image3">
+                                    <img src="{{ url_for('static', filename='images/page/mask-home4.jpg') }}" alt="image" class="image4">
+                                    <img src="{{ url_for('static', filename='images/page/cycle-mask.png') }}" alt="image" class="image5">
                                 </div>
                             </div>
                         </div>
@@ -286,9 +286,9 @@
                             <div class="col-md-6">
                                 <div class="can-do-it-image relative">
                                     <div class="elip"></div>
-                                    <img src="./assets/images/page/image-feature-h41.jpg" alt="image"
+                                    <img src="{{ url_for('static', filename='images/page/image-feature-h41.jpg') }}" alt="image"
                                         class="cdit-image">
-                                    <img src="./assets/images/page/image-feature-h42.jpg" alt="image"
+                                    <img src="{{ url_for('static', filename='images/page/image-feature-h42.jpg') }}" alt="image"
                                         class="cdit-image1">
                                     <div class="quote-feature-wrap">
                                         <div class="counter tf-counter">
@@ -406,7 +406,7 @@
                                                     </div>
                                                 </div>
                                                 <div class="image-box3-image">
-                                                    <img src="./assets/images/image-box/feature1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/feature1.jpg') }}" alt="image">
                                                 </div>
 
                                             </div>
@@ -434,7 +434,7 @@
                                                     </div>
                                                 </div>
                                                 <div class="image-box3-image">
-                                                    <img src="./assets/images/image-box/feature.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/feature.jpg') }}" alt="image">
                                                 </div>
 
                                             </div>
@@ -462,7 +462,7 @@
                                                     </div>
                                                 </div>
                                                 <div class="image-box3-image">
-                                                    <img src="./assets/images/image-box/feature1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/feature1.jpg') }}" alt="image">
                                                 </div>
 
                                             </div>
@@ -490,7 +490,7 @@
                                                     </div>
                                                 </div>
                                                 <div class="image-box3-image">
-                                                    <img src="./assets/images/image-box/feature.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/feature.jpg') }}" alt="image">
                                                 </div>
 
                                             </div>
@@ -587,8 +587,8 @@
                                             </div>
                                             <div class="col-lg-5">
                                                 <div class="tab-service-image relative">
-                                                    <img src="./assets/images/service/service-h41.jpg" alt="image">
-                                                    <img src="./assets/images/service/service-h42.jpg" alt="image"
+                                                    <img src="{{ url_for('static', filename='images/service/service-h41.jpg') }}" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/service/service-h42.jpg') }}" alt="image"
                                                         class="service1">
                                                     <div class="clip"></div>
                                                 </div>
@@ -630,8 +630,8 @@
                                             </div>
                                             <div class="col-lg-5">
                                                 <div class="tab-service-image relative">
-                                                    <img src="./assets/images/service/service-h41.jpg" alt="image">
-                                                    <img src="./assets/images/service/service-h42.jpg" alt="image"
+                                                    <img src="{{ url_for('static', filename='images/service/service-h41.jpg') }}" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/service/service-h42.jpg') }}" alt="image"
                                                         class="service1">
                                                     <div class="clip"></div>
                                                 </div>
@@ -673,8 +673,8 @@
                                             </div>
                                             <div class="col-lg-5">
                                                 <div class="tab-service-image relative">
-                                                    <img src="./assets/images/service/service-h41.jpg" alt="image">
-                                                    <img src="./assets/images/service/service-h42.jpg" alt="image"
+                                                    <img src="{{ url_for('static', filename='images/service/service-h41.jpg') }}" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/service/service-h42.jpg') }}" alt="image"
                                                         class="service1">
                                                     <div class="clip"></div>
                                                 </div>
@@ -716,8 +716,8 @@
                                             </div>
                                             <div class="col-lg-5">
                                                 <div class="tab-service-image relative">
-                                                    <img src="./assets/images/service/service-h41.jpg" alt="image">
-                                                    <img src="./assets/images/service/service-h42.jpg" alt="image"
+                                                    <img src="{{ url_for('static', filename='images/service/service-h41.jpg') }}" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/service/service-h42.jpg') }}" alt="image"
                                                         class="service1">
                                                     <div class="clip"></div>
                                                 </div>
@@ -787,7 +787,7 @@
                                     </div>
                                     <div class="image relative">
                                         <a href="team-details.html">
-                                            <img src="./assets/images/team/team1.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/team1.jpg') }}" alt="image">
                                         </a>                                       
                                         <ul class="social-team flex-five bg-8">
                                             <li>
@@ -816,7 +816,7 @@
                                     </div>
                                     <div class="image relative">
                                         <a href="team-details.html">
-                                            <img src="./assets/images/team/team2.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/team2.jpg') }}" alt="image">
                                         </a>                                      
                                         <ul class="social-team flex-five bg-8">
                                             <li>
@@ -845,7 +845,7 @@
                                     </div>
                                     <div class="image relative">
                                         <a href="team-details.html">
-                                            <img src="./assets/images/team/team3.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/team3.jpg') }}" alt="image">
                                         </a>                                      
                                         <ul class="social-team flex-five bg-8">
                                             <li>
@@ -874,7 +874,7 @@
                                     </div>
                                     <div class="image relative">
                                         <a href="team-details.html">
-                                            <img src="./assets/images/team/team4.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/team4.jpg') }}" alt="image">
                                         </a> 
                                         
                                         <ul class="social-team flex-five bg-8">
@@ -979,8 +979,8 @@
                             </div>
                             <div class="col-lg-6">
                                 <div class="wcus-section4-image relative">
-                                    <img src="./assets/images/page/w-c-us-home4.jpg" alt="image" class="wcus-h41">
-                                    <img src="./assets/images/page/wcus-h4-2.png" alt="image" class="wcus-h42">
+                                    <img src="{{ url_for('static', filename='images/page/w-c-us-home4.jpg') }}" alt="image" class="wcus-h41">
+                                    <img src="{{ url_for('static', filename='images/page/wcus-h4-2.png') }}" alt="image" class="wcus-h42">
                                     <div class="clip"></div>
                                 </div>
                             </div>
@@ -994,7 +994,7 @@
                         <div class="row">
                             <div class="col-lg-2">
                                 <div class="image-faq-left">
-                                    <img src="./assets/images/page/faq-h41.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/faq-h41.jpg') }}" alt="image">
                                 </div>
                             </div>
                             <div class="col-lg-8">
@@ -1102,7 +1102,7 @@
                             </div>
                             <div class="col-lg-2">
                                 <div class="image-faq-right">
-                                    <img src="./assets/images/page/faq-h42.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/faq-h42.jpg') }}" alt="image">
                                 </div>
                             </div>
                         </div>
@@ -1137,7 +1137,7 @@
                                                     see the world, not so the world can see you.
                                                 </p>
                                                 <div class="testimonial-bottom flex-two">
-                                                    <img src="./assets/images/brand/test-h4.png" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/brand/test-h4.png') }}" alt="image">
                                                     <div class="review">
                                                         <i class="icon-start"></i>
                                                         <i class="icon-start"></i>
@@ -1160,7 +1160,7 @@
                                                     see the world, not so the world can see you.
                                                 </p>
                                                 <div class="testimonial-bottom flex-two">
-                                                    <img src="./assets/images/brand/test-h4.png" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/brand/test-h4.png') }}" alt="image">
                                                     <div class="review">
                                                         <i class="icon-start"></i>
                                                         <i class="icon-start"></i>
@@ -1183,7 +1183,7 @@
                                                     see the world, not so the world can see you.
                                                 </p>
                                                 <div class="testimonial-bottom flex-two">
-                                                    <img src="./assets/images/brand/test-h4.png" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/brand/test-h4.png') }}" alt="image">
                                                     <div class="review">
                                                         <i class="icon-start"></i>
                                                         <i class="icon-start"></i>
@@ -1215,7 +1215,7 @@
                                     </li>
                                 </ul>
                                 <div class="service-cta ">
-                                    <img src="./assets/images/page/chat1.png" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/chat1.png') }}" alt="image">
                                     <p class="font-man">Get Free Consultations For Solutions</p>
                                     <a href="#">Get A Quote <i class="icon-right-icon"></i></a>
                                 </div>
@@ -1330,7 +1330,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".3s">
                                 <div class="tf-blog-style3 mr-3em bg-sd">
                                     <a href="#" class="image">
-                                        <img src="./assets/images/blog/blog-h41.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/blog/blog-h41.jpg') }}" alt="image">
                                     </a>
                                     <div class="content style2">
                                         <span class="date font-man texts-blue">October 25, 2025</span>
@@ -1347,7 +1347,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".4s" >
                                 <div class="tf-blog-style3 bg-sd">
                                     <a href="blog-details.html" class="image">
-                                        <img src="./assets/images/blog/blog-h42.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/blog/blog-h42.jpg') }}" alt="image">
                                     </a>
                                     <div class="content style2">
                                         <span class="date font-man texts-blue">October 25, 2025</span>
@@ -1362,7 +1362,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".5s">
                                 <div class="tf-blog-style3 ml-3em bg-sd">
                                     <a href="blog-details.html" class="image">
-                                        <img src="./assets/images/blog/blog-h43.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/blog/blog-h43.jpg') }}" alt="image">
                                     </a>
                                     <div class="content style2">
                                         <span class="date font-man texts-blue">October 25, 2025</span>
@@ -1389,62 +1389,62 @@
                                     <div class="swiper-wrapper">
                                         <div class="swiper-slide">
                                             <div class="brand-item flex-five effect-1">
-                                                <img src="./assets/images/brand/br1.png" alt="image">
-                                                <img src="./assets/images/brand/brh11.png" alt="image" class="first">
+                                                <img src="{{ url_for('static', filename='images/brand/br1.png') }}" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/brh11.png') }}" alt="image" class="first">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="brand-item flex-five effect-1">
-                                                <img src="./assets/images/brand/br4.png" alt="image">
-                                                <img src="./assets/images/brand/br-h12.png" alt="image" class="first">
+                                                <img src="{{ url_for('static', filename='images/brand/br4.png') }}" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br-h12.png') }}" alt="image" class="first">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="brand-item flex-five effect-1">
-                                                <img src="./assets/images/brand/br5.png" alt="image">
-                                                <img src="./assets/images/brand/br-h14.png" alt="image" class="first">
+                                                <img src="{{ url_for('static', filename='images/brand/br5.png') }}" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br-h14.png') }}" alt="image" class="first">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="brand-item flex-five effect-1">
-                                                <img src="./assets/images/brand/br7.png" alt="image">
-                                                <img src="./assets/images/brand/br-h13.png" alt="image" class="first">
+                                                <img src="{{ url_for('static', filename='images/brand/br7.png') }}" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br-h13.png') }}" alt="image" class="first">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="brand-item flex-five effect-1">
-                                                <img src="./assets/images/brand/br10.png" alt="image">
-                                                <img src="./assets/images/brand/br-h15.png" alt="image"  class="first">
+                                                <img src="{{ url_for('static', filename='images/brand/br10.png') }}" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br-h15.png') }}" alt="image"  class="first">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="brand-item flex-five effect-1">
-                                                <img src="./assets/images/brand/br1.png" alt="image">
-                                                <img src="./assets/images/brand/brh11.png" alt="image" class="first">
+                                                <img src="{{ url_for('static', filename='images/brand/br1.png') }}" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/brh11.png') }}" alt="image" class="first">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="brand-item flex-five effect-1">
-                                                <img src="./assets/images/brand/br4.png" alt="image">
-                                                <img src="./assets/images/brand/br-h12.png" alt="image" class="first">
+                                                <img src="{{ url_for('static', filename='images/brand/br4.png') }}" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br-h12.png') }}" alt="image" class="first">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="brand-item flex-five effect-1">
-                                                <img src="./assets/images/brand/br5.png" alt="image">
-                                                <img src="./assets/images/brand/br-h14.png" alt="image" class="first">
+                                                <img src="{{ url_for('static', filename='images/brand/br5.png') }}" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br-h14.png') }}" alt="image" class="first">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="brand-item flex-five effect-1">
-                                                <img src="./assets/images/brand/br7.png" alt="image">
-                                                <img src="./assets/images/brand/br-h13.png" alt="image" class="first">
+                                                <img src="{{ url_for('static', filename='images/brand/br7.png') }}" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br-h13.png') }}" alt="image" class="first">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="brand-item flex-five effect-1">
-                                                <img src="./assets/images/brand/br10.png" alt="image">
-                                                <img src="./assets/images/brand/br-h15.png" alt="image"  class="first">
+                                                <img src="{{ url_for('static', filename='images/brand/br10.png') }}" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br-h15.png') }}" alt="image"  class="first">
                                             </div>
                                         </div>
                                         
@@ -1501,7 +1501,7 @@
                     </div>
                     <div class="footer-main4 flex">
                         <div class="footer-item-logo">
-                            <img src="./assets/images/logo-footer3.png" alt="image" class="logo-footer">
+                            <img src="{{ url_for('static', filename='images/logo-footer3.png') }}" alt="image" class="logo-footer">
                             <p class="des">Sed ut persiciatis unde omnis natus voluptatem accusantium dolore</p>
                             <div class="follow-social">
                                 <h6 class="title">Follow Us</h6>

--- a/templates/home5.html
+++ b/templates/home5.html
@@ -168,7 +168,7 @@
             <main id="main">
                 <!--  Main Slider -->
                 <section class="banner-home5 bg-1 relative">
-                    <img src="./assets/images/page/mask-hero.png" alt="image" class="mask-hero">
+                    <img src="{{ url_for('static', filename='images/page/mask-hero.png') }}" alt="image" class="mask-hero">
                     <div class="tf-container">
                         <div class="row banner-home5-wrap">
                             <div class="col-md-6">
@@ -192,7 +192,7 @@
                             </div>
                             <div class="col-md-6">
                                 <div class="image">
-                                    <img src="./assets/images/page/image-hero.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/image-hero.jpg') }}" alt="image">
                                 </div>
                             </div>
                         </div>
@@ -298,7 +298,7 @@
                                 <div class="service-item-list">
                                     <div class="service-item flex-three wow fadeInUpSmall" data-wow-delay=".3s">
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu1.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu1.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Design <span class="number">01</span></p>
@@ -313,7 +313,7 @@
                                     </div>
                                     <div class="service-item flex-three wow fadeInUpSmall" data-wow-delay=".4s">
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu2.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu2.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Development <span class="number">02</span></p>
@@ -327,7 +327,7 @@
                                     </div>
                                     <div class="service-item flex-three wow fadeInUpSmall" data-wow-delay=".4s">
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu3.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu3.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Marketing <span class="number">03</span></p>
@@ -341,7 +341,7 @@
                                     </div>
                                     <div class="service-item flex-three wow fadeInUpSmall" data-wow-delay=".5s">
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu4.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu4.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Motion Design <span class="number">04</span></p>
@@ -355,7 +355,7 @@
                                     </div>
                                     <div class="service-item flex-three wow fadeInUpSmall" data-wow-delay=".6s">
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu5.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu5.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Content <span class="number">05</span></p>
@@ -379,7 +379,7 @@
 
                 <!--  About us -->
                 <section class="about-us-home5 pt-122 pb-130 bg-1 relative">
-                    <img src="./assets/images/page/mask-ab5.png" alt="image" class="mask-about-h5">
+                    <img src="{{ url_for('static', filename='images/page/mask-ab5.png') }}" alt="image" class="mask-about-h5">
                     <div class="tf-container">
                         <div class="row z-index-3 relative">
                             <div class="col-md-6">
@@ -401,7 +401,7 @@
                             </div>
                             <div class="col-md-6">
                                 <div class="about-us-h5-image">
-                                    <img src="./assets/images/page/image-ab-home.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/image-ab-home.jpg') }}" alt="image">
                                     <p class="des">We denounce with righteous indignation and dislike men who are so
                                         beguiled and demoralized by the charms of pleasure of the moment, so blinded by
                                         desire that they
@@ -469,7 +469,7 @@
                                         <div class="swiper-slide">
                                             <div class="tf-portfolio">
                                                 <a href="project-details.html" class="image">
-                                                    <img src="./assets/images/image-box/case1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/case1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <div class="inner-title">
@@ -488,7 +488,7 @@
                                         <div class="swiper-slide">
                                             <div class="tf-portfolio">
                                                 <a href="project-details.html" class="image">
-                                                    <img src="./assets/images/image-box/case2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/case2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <div class="inner-title">
@@ -507,7 +507,7 @@
                                         <div class="swiper-slide">
                                             <div class="tf-portfolio">
                                                 <a href="project-details.html" class="image">
-                                                    <img src="./assets/images/image-box/case3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/case3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <div class="inner-title">
@@ -526,7 +526,7 @@
                                         <div class="swiper-slide">
                                             <div class="tf-portfolio">
                                                 <a href="project-details.html" class="image">
-                                                    <img src="./assets/images/image-box/case1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/case1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <div class="inner-title">
@@ -545,7 +545,7 @@
                                         <div class="swiper-slide">
                                             <div class="tf-portfolio">
                                                 <a href="project-details.html" class="image">
-                                                    <img src="./assets/images/image-box/case2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/case2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <div class="inner-title">
@@ -564,7 +564,7 @@
                                         <div class="swiper-slide">
                                             <div class="tf-portfolio">
                                                 <a href="project-details.html" class="image">
-                                                    <img src="./assets/images/image-box/case3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/case3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <div class="inner-title">
@@ -896,7 +896,7 @@
                                             <div class="swiper-slide">
                                                 <div class="testimonial-style3 style3-h5 flex-three">
                                                     <div class="image">
-                                                        <img src="./assets/images/testimonial/avt.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/testimonial/avt.jpg') }}" alt="image">
                                                     </div>
                                                     <div class="content">
                                                         <p class="des">Climb the mountain not to plant your flag but to
@@ -926,7 +926,7 @@
                                             <div class="swiper-slide">
                                                 <div class="testimonial-style3 style3-h5 flex-three">
                                                     <div class="image">
-                                                        <img src="./assets/images/testimonial/avt.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/testimonial/avt.jpg') }}" alt="image">
                                                     </div>
                                                     <div class="content">
                                                         <p class="des">Climb the mountain not to plant your flag but to
@@ -956,7 +956,7 @@
                                             <div class="swiper-slide">
                                                 <div class="testimonial-style3 style3-h5 flex-three">
                                                     <div class="image">
-                                                        <img src="./assets/images/testimonial/avt.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/testimonial/avt.jpg') }}" alt="image">
                                                     </div>
                                                     <div class="content">
                                                         <p class="des">Climb the mountain not to plant your flag but to
@@ -1011,7 +1011,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".2s">
                                 <div class="tf-blog-style3 ">
                                     <a href="blog-details.html" class="image relative">
-                                        <img src="./assets/images/blog/blog-h51.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/blog/blog-h51.jpg') }}" alt="image">
                                         <span class="date-ab">25 Dec</span>
                                     </a>
                                     <div class="content style3">
@@ -1028,7 +1028,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".3s">
                                 <div class="tf-blog-style3">
                                     <a href="blog-details.html" class="image relative">
-                                        <img src="./assets/images/blog/blog-h52.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/blog/blog-h52.jpg') }}" alt="image">
                                         <span class="date-ab">25 Dec</span>
                                     </a>
                                     <div class="content style3">
@@ -1045,7 +1045,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".4s">
                                 <div class="tf-blog-style3">
                                     <a href="blog-details.html" class="image relative">
-                                        <img src="./assets/images/blog/blog-h53.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/blog/blog-h53.jpg') }}" alt="image">
                                         <span class="date-ab">25 Dec</span>
                                     </a>
                                     <div class="content style3">
@@ -1082,27 +1082,27 @@
                                     <div class="swiper-wrapper">
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br1.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br1.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br2.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br2.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br3.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br3.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br4.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br4.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br5.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br5.png') }}" alt="image">
                                             </div>
                                         </div>
                                     </div>
@@ -1113,27 +1113,27 @@
                                     <div class="swiper-wrapper">
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br6.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br6.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br7.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br7.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br9.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br9.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br10.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br10.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br8.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br8.png') }}" alt="image">
                                             </div>
                                         </div>
                                     </div>
@@ -1152,7 +1152,7 @@
                     <div class="row footer-top5">
                         <div class="col-md-3">
                             <div class="logo-footer">
-                                <img src="./assets/images/logo-footer2.png" alt="image">
+                                <img src="{{ url_for('static', filename='images/logo-footer2.png') }}" alt="image">
                             </div>
                         </div>
                         <div class="col-md-9">

--- a/templates/home6.html
+++ b/templates/home6.html
@@ -168,7 +168,7 @@
             <main id="main">
                 <!--  Main Slider -->
                 <section class="banner-home5 bg-1 relative">
-                    <img src="./assets/images/page/mask-hero.png" alt="image" class="mask-hero">
+                    <img src="{{ url_for('static', filename='images/page/mask-hero.png') }}" alt="image" class="mask-hero">
                     <div class="tf-container">
                         <div class="row banner-home5-wrap">
                             <div class="col-md-6">
@@ -192,7 +192,7 @@
                             </div>
                             <div class="col-md-6">
                                 <div class="image">
-                                    <img src="./assets/images/page/image-hero.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/image-hero.jpg') }}" alt="image">
                                 </div>
                             </div>
                         </div>
@@ -299,7 +299,7 @@
                                 <div class="service-item-list">
                                     <div class="service-item flex-three service-dark wow fadeInUpSmall" data-wow-delay=".3s" >
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu1.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu1.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Design <span class="number">01</span></p>
@@ -314,7 +314,7 @@
                                     </div>
                                     <div class="service-item flex-three service-dark wow fadeInUpSmall" data-wow-delay=".4s">
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu2.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu2.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Development <span class="number">02</span></p>
@@ -328,7 +328,7 @@
                                     </div>
                                     <div class="service-item flex-three service-dark wow fadeInUpSmall" data-wow-delay=".4s">
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu3.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu3.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Marketing <span class="number">03</span></p>
@@ -342,7 +342,7 @@
                                     </div>
                                     <div class="service-item flex-three service-dark wow fadeInUpSmall" data-wow-delay=".5s">
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu4.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu4.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Motion Design <span class="number">04</span></p>
@@ -356,7 +356,7 @@
                                     </div>
                                     <div class="service-item flex-three service-dark wow fadeInUpSmall" data-wow-delay=".6s" >
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu5.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu5.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Content <span class="number">05</span></p>
@@ -380,7 +380,7 @@
 
                 <!--  About us -->
                 <section class="about-us-home5 pt-122 pb-130 bg-9 relative">
-                    <img src="./assets/images/page/mask-ab5.png" alt="image" class="mask-about-h5">
+                    <img src="{{ url_for('static', filename='images/page/mask-ab5.png') }}" alt="image" class="mask-about-h5">
                     <div class="tf-container">
                         <div class="row z-index-3 relative">
                             <div class="col-md-6">
@@ -402,7 +402,7 @@
                             </div>
                             <div class="col-md-6">
                                 <div class="about-us-h5-image">
-                                    <img src="./assets/images/page/image-ab-home.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/image-ab-home.jpg') }}" alt="image">
                                     <p class="des">We denounce with righteous indignation and dislike men who are so
                                         beguiled and demoralized by the charms of pleasure of the moment, so blinded by
                                         desire that they
@@ -470,7 +470,7 @@
                                         <div class="swiper-slide">
                                             <div class="tf-portfolio portfolio-dark">
                                                 <a href="project-details.html" class="image">
-                                                    <img src="./assets/images/image-box/case1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/case1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <div class="inner-title">
@@ -489,7 +489,7 @@
                                         <div class="swiper-slide">
                                             <div class="tf-portfolio portfolio-dark">
                                                 <a href="project-details.html" class="image">
-                                                    <img src="./assets/images/image-box/case2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/case2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <div class="inner-title">
@@ -508,7 +508,7 @@
                                         <div class="swiper-slide">
                                             <div class="tf-portfolio portfolio-dark">
                                                 <a href="project-details.html" class="image">
-                                                    <img src="./assets/images/image-box/case3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/case3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <div class="inner-title">
@@ -527,7 +527,7 @@
                                         <div class="swiper-slide">
                                             <div class="tf-portfolio portfolio-dark">
                                                 <a href="project-details.html" class="image">
-                                                    <img src="./assets/images/image-box/case1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/case1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <div class="inner-title">
@@ -546,7 +546,7 @@
                                         <div class="swiper-slide">
                                             <div class="tf-portfolio portfolio-dark">
                                                 <a href="project-details.html" class="image">
-                                                    <img src="./assets/images/image-box/case2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/case2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <div class="inner-title">
@@ -565,7 +565,7 @@
                                         <div class="swiper-slide">
                                             <div class="tf-portfolio portfolio-dark">
                                                 <a href="project-details.html" class="image">
-                                                    <img src="./assets/images/image-box/case3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/image-box/case3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content">
                                                     <div class="inner-title">
@@ -897,7 +897,7 @@
                                             <div class="swiper-slide">
                                                 <div class="testimonial-style3 style3-h5 flex-three testimonial-style3-dark">
                                                     <div class="image">
-                                                        <img src="./assets/images/testimonial/avt.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/testimonial/avt.jpg') }}" alt="image">
                                                     </div>
                                                     <div class="content">
                                                         <p class="des">Climb the mountain not to plant your flag but to
@@ -927,7 +927,7 @@
                                             <div class="swiper-slide">
                                                 <div class="testimonial-style3 style3-h5 flex-three testimonial-style3-dark">
                                                     <div class="image">
-                                                        <img src="./assets/images/testimonial/avt.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/testimonial/avt.jpg') }}" alt="image">
                                                     </div>
                                                     <div class="content">
                                                         <p class="des">Climb the mountain not to plant your flag but to
@@ -957,7 +957,7 @@
                                             <div class="swiper-slide">
                                                 <div class="testimonial-style3 style3-h5 flex-three testimonial-style3-dark">
                                                     <div class="image">
-                                                        <img src="./assets/images/testimonial/avt.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/testimonial/avt.jpg') }}" alt="image">
                                                     </div>
                                                     <div class="content">
                                                         <p class="des">Climb the mountain not to plant your flag but to
@@ -1012,7 +1012,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".2s">
                                 <div class="tf-blog-style3 blog-style3-dark">
                                     <a href="blog-details.html" class="image relative">
-                                        <img src="./assets/images/blog/blog-h51.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/blog/blog-h51.jpg') }}" alt="image">
                                         <span class="date-ab">25 Dec</span>
                                     </a>
                                     <div class="content style3">
@@ -1029,7 +1029,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".3s">
                                 <div class="tf-blog-style3 blog-style3-dark">
                                     <a href="blog-details.html" class="image relative">
-                                        <img src="./assets/images/blog/blog-h52.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/blog/blog-h52.jpg') }}" alt="image">
                                         <span class="date-ab">25 Dec</span>
                                     </a>
                                     <div class="content style3">
@@ -1046,7 +1046,7 @@
                             <div class="col-md-4 wow fadeInUpSmall" data-wow-delay=".4s">
                                 <div class="tf-blog-style3 blog-style3-dark">
                                     <a href="blog-details.html" class="image relative">
-                                        <img src="./assets/images/blog/blog-h53.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/blog/blog-h53.jpg') }}" alt="image">
                                         <span class="date-ab">25 Dec</span>
                                     </a>
                                     <div class="content style3">
@@ -1083,27 +1083,27 @@
                                     <div class="swiper-wrapper">
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br1.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br1.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br2.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br2.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br3.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br3.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br4.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br4.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br5.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br5.png') }}" alt="image">
                                             </div>
                                         </div>
                                     </div>
@@ -1114,27 +1114,27 @@
                                     <div class="swiper-wrapper">
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br6.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br6.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br7.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br7.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br9.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br9.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br10.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br10.png') }}" alt="image">
                                             </div>
                                         </div>
                                         <div class="swiper-slide">
                                             <div class="image-partner-logo">
-                                                <img src="./assets/images/brand/br8.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br8.png') }}" alt="image">
                                             </div>
                                         </div>
                                     </div>
@@ -1153,7 +1153,7 @@
                     <div class="row footer-top5">
                         <div class="col-md-3">
                             <div class="logo-footer">
-                                <img src="./assets/images/logo-footer2.png" alt="image">
+                                <img src="{{ url_for('static', filename='images/logo-footer2.png') }}" alt="image">
                             </div>
                         </div>
                         <div class="col-md-9">

--- a/templates/index.html
+++ b/templates/index.html
@@ -227,10 +227,10 @@
                             <div class="swiper-slide">
                                 <div class="slider-it-main relative over overflow-hiden">
                                     <div class="slider-image-it">
-                                        <img src="./assets/images/slide/slider1lider1.jpg" alt="">
+                                        <img src="{{ url_for('static', filename='images/slide/slider1lider1.jpg') }}" alt="">
                                     </div>
                                     <span class="it-solution fw-600">IT Solutions</span>
-                                    <img src="./assets/images/slide/mask.png" alt="image" class="mask-slider">
+                                    <img src="{{ url_for('static', filename='images/slide/mask.png') }}" alt="image" class="mask-slider">
                                     <div class="tf-container">
                                         <div class="slider-content-it relative z-index-3">
                                             <div class="sub-title-slider wow fadeInUpSmall">
@@ -256,10 +256,10 @@
                             <div class="swiper-slide">
                                 <div class="slider-it-main relative over overflow-hiden">
                                     <div class="slider-image-it">
-                                        <img src="./assets/images/slide/slider1lider2.jpg" alt="">
+                                        <img src="{{ url_for('static', filename='images/slide/slider1lider2.jpg') }}" alt="">
                                     </div>
                                     <span class="it-solution fw-600">IT Solutions</span>
-                                    <img src="./assets/images/slide/mask.png" alt="image" class="mask-slider">
+                                    <img src="{{ url_for('static', filename='images/slide/mask.png') }}" alt="image" class="mask-slider">
                                     <div class="tf-container">
                                         <div class="slider-content-it relative z-index-3">
                                             <div class="sub-title-slider wow fadeInUpSmall">
@@ -297,25 +297,25 @@
                                     <div class="swiper brand-logo overflow-hiden">
                                         <div class="swiper-wrapper">
                                             <div class="swiper-slide">
-                                                <img src="./assets/images/brand/brh11.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/brh11.png') }}" alt="image">
                                             </div>
                                             <div class="swiper-slide">
-                                                <img src="./assets/images/brand/br-h12.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br-h12.png') }}" alt="image">
                                             </div>
                                             <div class="swiper-slide">
-                                                <img src="./assets/images/brand/br-h13.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br-h13.png') }}" alt="image">
                                             </div>
                                             <div class="swiper-slide">
-                                                <img src="./assets/images/brand/br-h14.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br-h14.png') }}" alt="image">
                                             </div>
                                             <div class="swiper-slide">
-                                                <img src="./assets/images/brand/br-h15.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br-h15.png') }}" alt="image">
                                             </div>
                                             <div class="swiper-slide">
-                                                <img src="./assets/images/brand/br-h16.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br-h16.png') }}" alt="image">
                                             </div>
                                             <div class="swiper-slide">
-                                                <img src="./assets/images/brand/br-h13.png" alt="image">
+                                                <img src="{{ url_for('static', filename='images/brand/br-h13.png') }}" alt="image">
                                             </div>
                                         </div>
                                     </div>
@@ -404,7 +404,7 @@
                             <div class="row">
                                 <div class="col-12 col-md-6 col-lg-6 col-xl-4">
                                     <div class="about-us-image relative">
-                                        <img src="./assets/images/page/about-h1.jpg" alt="image" class="wow zoomIn" data-wow-delay=".3s">                                                                       
+                                        <img src="{{ url_for('static', filename='images/page/about-h1.jpg') }}" alt="image" class="wow zoomIn" data-wow-delay=".3s">                                                                       
                                         <div class="vector wow fadeInLeft" data-wow-delay=".3s">
                                             <svg width="202" height="200" viewBox="0 0 202 200" fill="none"
                                                 xmlns="http://www.w3.org/2000/svg">
@@ -682,7 +682,7 @@
                             </div>
                             <div class="center wow fadeInUpSmall" data-wow-delay=".3s">
                                 <div class="service-cta">
-                                    <img src="./assets/images/page/chat1.png" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/chat1.png') }}" alt="image">
                                     <p class="font-man">Get Free Consultations For Tech Solutions</p>
                                     <a href="#">Get A Quote <i class="icon-right-icon"></i></a>
                                 </div>
@@ -763,7 +763,7 @@
                                 </div>
                                 <div class="col-lg-12 col-xl-7">
                                     <div class="image relative">
-                                        <img src="./assets/images/page/feature-h1.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/page/feature-h1.jpg') }}" alt="image">
                                         <div class="quote-feature-wrap">
                                             <div class="counter  tf-counters">
                                                 <div class="numbers number-style" data-speed="2000" data-to="25"
@@ -841,7 +841,7 @@
                             </svg>
                         </div>
                         <div class="shape-team1">
-                            <img src="./assets/images/page/circel.png" alt="image">
+                            <img src="{{ url_for('static', filename='images/page/circel.png') }}" alt="image">
                         </div>
                         <div class="shape-team2"></div>
                         <div class="tf-container">
@@ -901,7 +901,7 @@
                                         <div class="item-team-member team-post team-post-11 item1 relative"
                                             data-id="11">
                                             <a href="team-details.html">
-                                                <img src="./assets/images/team/teamh1.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/team/teamh1.jpg') }}" alt="image">
                                             </a>
                                             <ul class="social-team flex-three">
                                                 <li>
@@ -922,7 +922,7 @@
                                         <div class="item-team-member team-post team-post-22 item2 relative"
                                             data-id="22">
                                             <a href="team-details.html">
-                                                <img src="./assets/images/team/teamh11.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/team/teamh11.jpg') }}" alt="image">
                                             </a>
                                             <ul class="social-team flex-three">
                                                 <li>
@@ -942,7 +942,7 @@
                                         <div class="item-team-member team-post team-post-33 item3 relative"
                                             data-id="33">
                                             <a href="team-details.html">
-                                                <img src="./assets/images/team/teamh12.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/team/teamh12.jpg') }}" alt="image">
                                             </a>
                                             <ul class="social-team flex-three">
                                                 <li>
@@ -962,7 +962,7 @@
                                         <div class="item-team-member team-post team-post-44 item4 relative"
                                             data-id="44">
                                             <a href="team-details.html">
-                                                <img src="./assets/images/team/teamh13.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/team/teamh13.jpg') }}" alt="image">
                                             </a>
                                             <ul class="social-team flex-three">
                                                 <li>
@@ -996,13 +996,13 @@
                                     <div class="swiper  case-studies-slider overflow-hiden mb-60">
                                         <div class="swiper-wrapper">
                                             <div class="swiper-slide">
-                                                <img src="./assets/images/page/case-h1.jpg" alt="image silder">
+                                                <img src="{{ url_for('static', filename='images/page/case-h1.jpg') }}" alt="image silder">
                                             </div>
                                             <div class="swiper-slide">
-                                                <img src="./assets/images/page/case-h1.jpg" alt="image silder">
+                                                <img src="{{ url_for('static', filename='images/page/case-h1.jpg') }}" alt="image silder">
                                             </div>
                                             <div class="swiper-slide">
-                                                <img src="./assets/images/page/case-h1.jpg" alt="image silder">
+                                                <img src="{{ url_for('static', filename='images/page/case-h1.jpg') }}" alt="image silder">
                                             </div>
                                         </div>
                                         <div class="swiper-pagination"></div>
@@ -1119,7 +1119,7 @@
 
                     <!-- Testimonial -->
                     <section class="section-testimonial pt-122 pb-130 relative">
-                        <img src="./assets/images/testimonial/tes-h1.jpg" alt="image" class="tes-shape">
+                        <img src="{{ url_for('static', filename='images/testimonial/tes-h1.jpg') }}" alt="image" class="tes-shape">
                         <div class="tf-container">
                             <div class="row mb-60 z-index-3 relative">
                                 <div class="col-lg-12">
@@ -1138,7 +1138,7 @@
                                                 <div class="testimonial-style1 bd-rd-10">
                                                     <div class="flex-two testimonial-header">
                                                         <i class="icon-des"></i>
-                                                        <img src="./assets/images/brand/dropbox.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/dropbox.png') }}" alt="image">
                                                     </div>
                                                     <div class="line"></div>
                                                     <p class="des">With a proven track record delivering
@@ -1165,7 +1165,7 @@
                                                 <div class="testimonial-style1 bd-rd-10">
                                                     <div class="flex-two testimonial-header">
                                                         <i class="icon-des"></i>
-                                                        <img src="./assets/images/brand/br4.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br4.png') }}" alt="image">
                                                     </div>
                                                     <div class="line"></div>
                                                     <p class="des">With a proven track record delivering
@@ -1195,7 +1195,7 @@
                                                 <div class="testimonial-style1 bd-rd-10">
                                                     <div class="flex-two testimonial-header">
                                                         <i class="icon-des"></i>
-                                                        <img src="./assets/images/brand/br10.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br10.png') }}" alt="image">
                                                     </div>
                                                     <div class="line"></div>
                                                     <p class="des">With a proven track record delivering
@@ -1226,7 +1226,7 @@
                                                 <div class="testimonial-style1 bd-rd-10">
                                                     <div class="flex-two testimonial-header">
                                                         <i class="icon-des"></i>
-                                                        <img src="./assets/images/brand/dropbox.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/dropbox.png') }}" alt="image">
                                                     </div>
                                                     <div class="line"></div>
                                                     <p class="des">With a proven track record delivering
@@ -1253,7 +1253,7 @@
                                                 <div class="testimonial-style1 bd-rd-10">
                                                     <div class="flex-two testimonial-header">
                                                         <i class="icon-des"></i>
-                                                        <img src="./assets/images/brand/br4.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br4.png') }}" alt="image">
                                                     </div>
                                                     <div class="line"></div>
                                                     <p class="des">With a proven track record delivering
@@ -1283,7 +1283,7 @@
                                                 <div class="testimonial-style1 bd-rd-10">
                                                     <div class="flex-two testimonial-header">
                                                         <i class="icon-des"></i>
-                                                        <img src="./assets/images/brand/br10.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br10.png') }}" alt="image">
                                                     </div>
                                                     <div class="line"></div>
                                                     <p class="des">With a proven track record delivering
@@ -1334,7 +1334,7 @@
                                 <div class="col-md-6">
                                     <div class="tf-blog-style1 relative">
                                         <a href="blog-details.html" class="image overflow-hiden relative">
-                                            <img src="./assets/images/blog/blogh11.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/blog/blogh11.jpg') }}" alt="image">
                                         </a>
                                         <div class="content style1">
                                             <span class="date text-white font-man">October 25, 2025</span>
@@ -1359,7 +1359,7 @@
                                                         class="icon-right-icon"></i></a>
                                             </div>
                                             <a href="blog-details.html" class="image">
-                                                <img src="./assets/images/blog/bogh12.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/blog/bogh12.jpg') }}" alt="image">
                                             </a>
                                         </div>
                                         <div class="tf-blog-style2 blog-pd1 bb-blog flex wow fadeInUpSmall" data-wow-delay=".4s">
@@ -1374,7 +1374,7 @@
 
                                             </div>
                                             <a href="blog-details.html" class="image">
-                                                <img src="./assets/images/blog/blog-h13.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/blog/blog-h13.jpg') }}" alt="image">
                                             </a>
                                         </div>
                                         <div class="tf-blog-style2 blog-pd1 bb-blog flex wow fadeInUpSmall" data-wow-delay=".5s">
@@ -1389,7 +1389,7 @@
 
                                             </div>
                                             <a href="blog-details.html" class="image">
-                                                <img src="./assets/images/blog/blogh14.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/blog/blogh14.jpg') }}" alt="image">
                                             </a>
                                         </div>
 

--- a/templates/pricing.html
+++ b/templates/pricing.html
@@ -264,7 +264,7 @@
 
                             </div>
                             <div class="col-md-6">
-                                <img src="./assets/images/page/price.jpg" alt="image">
+                                <img src="{{ url_for('static', filename='images/page/price.jpg') }}" alt="image">
                             </div>
                         </div>
                     </div>

--- a/templates/project-details.html
+++ b/templates/project-details.html
@@ -272,10 +272,10 @@
                         </div>
                         <div class="row">
                             <div class="col-md-4">
-                                <img src="./assets/images/project/pj-details1.jpg" alt="image" class="image-two-project">
+                                <img src="{{ url_for('static', filename='images/project/pj-details1.jpg') }}" alt="image" class="image-two-project">
                             </div>
                             <div class="col-md-8">
-                                <img src="./assets/images/project/pj-details2.jpg" alt="image">
+                                <img src="{{ url_for('static', filename='images/project/pj-details2.jpg') }}" alt="image">
                             </div>
                         </div>
                         <div class="row interesting bb-blog">
@@ -353,10 +353,10 @@
                         </div>
                         <div class="row mb-100">
                             <div class="col-md-6">
-                                <img src="./assets/images/project/pj-details3.jpg" alt="image" class="image-two-project2">
+                                <img src="{{ url_for('static', filename='images/project/pj-details3.jpg') }}" alt="image" class="image-two-project2">
                             </div>
                             <div class="col-md-6">
-                                <img src="./assets/images/project/pj-details4.jpg" alt="image">
+                                <img src="{{ url_for('static', filename='images/project/pj-details4.jpg') }}" alt="image">
                             </div>
                         </div>
                         <div class="row align-center">

--- a/templates/project-grid.html
+++ b/templates/project-grid.html
@@ -267,7 +267,7 @@
                                         <div class="grid-col-project">
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -288,7 +288,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -309,7 +309,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -330,7 +330,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid4.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid4.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -351,7 +351,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid5.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid5.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -372,7 +372,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid6.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid6.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -393,7 +393,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid7.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid7.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -414,7 +414,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid8.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid8.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -435,7 +435,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid9.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid9.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -461,7 +461,7 @@
                                         <div class="grid-col-project">
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -482,7 +482,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -503,7 +503,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -524,7 +524,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid4.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid4.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -545,7 +545,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid5.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid5.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -566,7 +566,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid6.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid6.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -587,7 +587,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid7.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid7.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -608,7 +608,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid8.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid8.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -629,7 +629,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid9.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid9.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -655,7 +655,7 @@
                                         <div class="grid-col-project">
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -676,7 +676,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -697,7 +697,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -718,7 +718,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid4.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid4.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -739,7 +739,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid5.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid5.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -760,7 +760,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid6.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid6.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -781,7 +781,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid7.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid7.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -802,7 +802,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid8.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid8.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -823,7 +823,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid9.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid9.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -849,7 +849,7 @@
                                         <div class="grid-col-project">
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -870,7 +870,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -891,7 +891,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -912,7 +912,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid4.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid4.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -933,7 +933,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid5.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid5.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -954,7 +954,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid6.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid6.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -975,7 +975,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid7.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid7.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -996,7 +996,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid8.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid8.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1017,7 +1017,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid9.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid9.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1043,7 +1043,7 @@
                                         <div class="grid-col-project">
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1064,7 +1064,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1085,7 +1085,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1106,7 +1106,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid4.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid4.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1127,7 +1127,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid5.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid5.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1148,7 +1148,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid6.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid6.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1169,7 +1169,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid7.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid7.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1190,7 +1190,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid8.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid8.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1211,7 +1211,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-grid9.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-grid9.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">

--- a/templates/project-mansory.html
+++ b/templates/project-mansory.html
@@ -266,7 +266,7 @@
                                         <div class="grid-mansory-project">
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -287,7 +287,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -308,7 +308,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -329,7 +329,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason4.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason4.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -350,7 +350,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason5.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason5.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -371,7 +371,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason6.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason6.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -392,7 +392,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason7.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason7.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -413,7 +413,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason8.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason8.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -434,7 +434,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason9.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason9.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -460,7 +460,7 @@
                                         <div class="grid-mansory-project">
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -481,7 +481,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -502,7 +502,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -523,7 +523,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason4.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason4.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -544,7 +544,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason5.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason5.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -565,7 +565,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason6.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason6.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -586,7 +586,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason7.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason7.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -607,7 +607,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason8.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason8.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -628,7 +628,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason9.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason9.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -654,7 +654,7 @@
                                         <div class="grid-mansory-project">
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -675,7 +675,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -696,7 +696,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -717,7 +717,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason4.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason4.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -738,7 +738,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason5.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason5.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -759,7 +759,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason6.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason6.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -780,7 +780,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason7.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason7.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -801,7 +801,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason8.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason8.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -822,7 +822,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason9.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason9.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -848,7 +848,7 @@
                                         <div class="grid-mansory-project">
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -869,7 +869,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -890,7 +890,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -911,7 +911,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason4.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason4.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -932,7 +932,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason5.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason5.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -953,7 +953,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason6.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason6.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -974,7 +974,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason7.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason7.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -995,7 +995,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason8.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason8.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1016,7 +1016,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason9.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason9.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1042,7 +1042,7 @@
                                         <div class="grid-mansory-project">
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason1.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason1.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1063,7 +1063,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason2.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason2.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1084,7 +1084,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason3.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason3.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1105,7 +1105,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason4.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason4.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1126,7 +1126,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason5.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason5.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1147,7 +1147,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason6.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason6.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1168,7 +1168,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason7.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason7.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1189,7 +1189,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason8.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason8.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">
@@ -1210,7 +1210,7 @@
                                             </div>
                                             <div class="tf-image-box">
                                                 <a href="project-details.html" class="image relative overflow-hiden">
-                                                    <img src="./assets/images/project/pj-mason9.jpg" alt="image">
+                                                    <img src="{{ url_for('static', filename='images/project/pj-mason9.jpg') }}" alt="image">
                                                 </a>
                                                 <div class="content flex-two">
                                                     <div class="relative">

--- a/templates/project-slider.html
+++ b/templates/project-slider.html
@@ -249,7 +249,7 @@
                                       <div class="swiper-slide">
                                         <div class="tf-image-box bd-line">
                                             <a href="project-details.html" class="image relative overflow-hiden">
-                                                <img src="./assets/images/project/pj-slider1.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/project/pj-slider1.jpg') }}" alt="image">
                                             </a>
                                             <div class="content flex-two">
                                                 <div class="relative">
@@ -272,7 +272,7 @@
                                       <div class="swiper-slide">
                                         <div class="tf-image-box bd-line">
                                             <a href="project-details.html" class="image relative overflow-hiden">
-                                                <img src="./assets/images/project/pj-slider2.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/project/pj-slider2.jpg') }}" alt="image">
                                             </a>
                                             <div class="content flex-two">
                                                 <div class="relative">
@@ -295,7 +295,7 @@
                                       <div class="swiper-slide">
                                         <div class="tf-image-box bd-line">
                                             <a href="project-details.html" class="image relative overflow-hiden">
-                                                <img src="./assets/images/project/pj-slider3.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/project/pj-slider3.jpg') }}" alt="image">
                                             </a>
                                             <div class="content flex-two">
                                                 <div class="relative">
@@ -318,7 +318,7 @@
                                       <div class="swiper-slide">
                                         <div class="tf-image-box bd-line">
                                             <a href="project-details.html" class="image relative overflow-hiden">
-                                                <img src="./assets/images/project/pj-slider4.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/project/pj-slider4.jpg') }}" alt="image">
                                             </a>
                                             <div class="content flex-two">
                                                 <div class="relative">
@@ -341,7 +341,7 @@
                                       <div class="swiper-slide">
                                         <div class="tf-image-box bd-line">
                                             <a href="project-details.html" class="image relative overflow-hiden">
-                                                <img src="./assets/images/project/pj-slider1.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/project/pj-slider1.jpg') }}" alt="image">
                                             </a>
                                             <div class="content flex-two">
                                                 <div class="relative">
@@ -364,7 +364,7 @@
                                       <div class="swiper-slide">
                                         <div class="tf-image-box bd-line">
                                             <a href="project-details.html" class="image relative overflow-hiden">
-                                                <img src="./assets/images/project/pj-slider2.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/project/pj-slider2.jpg') }}" alt="image">
                                             </a>
                                             <div class="content flex-two">
                                                 <div class="relative">
@@ -387,7 +387,7 @@
                                       <div class="swiper-slide">
                                         <div class="tf-image-box bd-line">
                                             <a href="project-details.html" class="image relative overflow-hiden">
-                                                <img src="./assets/images/project/pj-slider3.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/project/pj-slider3.jpg') }}" alt="image">
                                             </a>
                                             <div class="content flex-two">
                                                 <div class="relative">
@@ -410,7 +410,7 @@
                                       <div class="swiper-slide">
                                         <div class="tf-image-box bd-line">
                                             <a href="project-details.html" class="image relative overflow-hiden">
-                                                <img src="./assets/images/project/pj-slider4.jpg" alt="image">
+                                                <img src="{{ url_for('static', filename='images/project/pj-slider4.jpg') }}" alt="image">
                                             </a>
                                             <div class="content flex-two">
                                                 <div class="relative">

--- a/templates/service-details.html
+++ b/templates/service-details.html
@@ -248,7 +248,7 @@
                                             accusantiue doloremue
                                             laudantium totam rem aperiam eaque ipsa quae abillo inventore veritatis</p>
                                     </div>
-                                    <img src="./assets/images/page/dvl-deatils.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/dvl-deatils.jpg') }}" alt="image">
                                 </div>
                             </div>
                             <div class="col-md-6">
@@ -420,7 +420,7 @@
                             </div>
                             <div class="col-md-5">
                                 <div class="it-manager-image">
-                                    <img src="./assets/images/page/dvl-deatils2.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/dvl-deatils2.jpg') }}" alt="image">
                                 </div>
                             </div>
                         </div>
@@ -496,7 +496,7 @@
                         <div class="row">
                             <div class="col-lg-12">
                                 <div class="video-about relative">
-                                    <img src="./assets/images/page/video-dvl.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/page/video-dvl.jpg') }}" alt="image">
                                     <div class="btn-video video-wrap">
                                         <a href="https://www.youtube.com/watch?v=rrtbyoYx8J4"
                                             class="tf-video flex-five widget-videos">
@@ -529,7 +529,7 @@
                                             <div class="swiper-slide">
                                                 <div class="testimonial-style3 style3-h5 flex-three">
                                                     <div class="image">
-                                                        <img src="./assets/images/testimonial/avt.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/testimonial/avt.jpg') }}" alt="image">
                                                     </div>
                                                     <div class="content">
                                                         <p class="des">Climb the mountain not to plant your flag but to
@@ -559,7 +559,7 @@
                                             <div class="swiper-slide">
                                                 <div class="testimonial-style3 style3-h5 flex-three">
                                                     <div class="image">
-                                                        <img src="./assets/images/testimonial/avt.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/testimonial/avt.jpg') }}" alt="image">
                                                     </div>
                                                     <div class="content">
                                                         <p class="des">Climb the mountain not to plant your flag but to
@@ -589,7 +589,7 @@
                                             <div class="swiper-slide">
                                                 <div class="testimonial-style3 style3-h5 flex-three">
                                                     <div class="image">
-                                                        <img src="./assets/images/testimonial/avt.jpg" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/testimonial/avt.jpg') }}" alt="image">
                                                     </div>
                                                     <div class="content">
                                                         <p class="des">Climb the mountain not to plant your flag but to

--- a/templates/service1.html
+++ b/templates/service1.html
@@ -268,7 +268,7 @@
                             <div class="col-md-4">
                                 <div class="tf-image-box2 style-dark">
                                     <a href="#" class="image">
-                                        <img src="./assets/images/image-box/os-h31.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/image-box/os-h31.jpg') }}" alt="image">
                                     </a>
                                     <div class="content">
                                         <span class="category">Startup Business</span>
@@ -289,7 +289,7 @@
                             <div class="col-md-4">
                                 <div class="tf-image-box2 style-dark">
                                     <a href="#" class="image">
-                                        <img src="./assets/images/image-box/os-h32.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/image-box/os-h32.jpg') }}" alt="image">
                                     </a>
                                     <div class="content">
                                         <span class="category">Small Business</span>
@@ -310,7 +310,7 @@
                             <div class="col-md-4">
                                 <div class="tf-image-box2 style-dark">
                                     <a href="#" class="image">
-                                        <img src="./assets/images/image-box/os-h33.jpg" alt="image">
+                                        <img src="{{ url_for('static', filename='images/image-box/os-h33.jpg') }}" alt="image">
                                     </a>
                                     <div class="content">
                                         <div class="category">Entrepreneur</div>
@@ -653,7 +653,7 @@
                             </div>
                             <div class="col-lg-6">
                                 <div class="feature-h3-image relative">
-                                    <img src="./assets/images/service/image-solution.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/service/image-solution.jpg') }}" alt="image">
                                     <div class="counting-feature bg-5">
                                         <div class="progress-box2 flex-three">
                                             <div class="progress-skill">
@@ -697,8 +697,8 @@
                             <div class="col-lg-6">
                                 <div class="image-wrapper-wcus3 relative">
                                     <div class="image-wcus3 flex">
-                                        <img src="./assets/images/service/cta-list1.jpg" alt="imge" class="wcus-pt">
-                                        <img src="./assets/images/service/cta-list2.jpg" alt="imge">
+                                        <img src="{{ url_for('static', filename='images/service/cta-list1.jpg') }}" alt="imge" class="wcus-pt">
+                                        <img src="{{ url_for('static', filename='images/service/cta-list2.jpg') }}" alt="imge">
                                     </div>
                                     <div class="quote-wcus-3 flex bg-5">
                                         <div class="icon">
@@ -766,7 +766,7 @@
                             </div>
                             <div class="col-md-5">
                                 <div class="image-cta-service">
-                                    <img src="./assets/images/service/cta-list3.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/service/cta-list3.jpg') }}" alt="image">
                                     <div class="quote-feature-wrap">
                                         <div class="counter  tf-counters">
                                             <div class="numbers number-style" data-speed="2000" data-to="25"

--- a/templates/service2.html
+++ b/templates/service2.html
@@ -268,7 +268,7 @@
                             </div>
                             <div class="col-md-6">
                                 <div class="feature-service2-image relative">
-                                    <img src="./assets/images/service/service-list.jpg" alt="image"
+                                    <img src="{{ url_for('static', filename='images/service/service-list.jpg') }}" alt="image"
                                         class="service2-image">
                                     <div class="testimonial-avt-box relative bg-5">
                                         <p>5m+ Trusted Global Clients</p>
@@ -362,7 +362,7 @@
                                 <div class="service-item-list">
                                     <div class="service-item flex-three">
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu1.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu1.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Design <span class="number">01</span></p>
@@ -377,7 +377,7 @@
                                     </div>
                                     <div class="service-item flex-three">
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu2.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu2.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Development <span class="number">02</span></p>
@@ -391,7 +391,7 @@
                                     </div>
                                     <div class="service-item flex-three">
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu3.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu3.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Marketing <span class="number">03</span></p>
@@ -405,7 +405,7 @@
                                     </div>
                                     <div class="service-item flex-three">
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu4.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu4.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Motion Design <span class="number">04</span></p>
@@ -419,7 +419,7 @@
                                     </div>
                                     <div class="service-item flex-three">
                                         <div class="image">
-                                            <img src="./assets/images/service/service-bu5.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/service/service-bu5.jpg') }}" alt="image">
                                         </div>
                                         <div class="content">
                                             <p class="category">Content <span class="number">05</span></p>
@@ -755,7 +755,7 @@
                             </div>
                             <div class="col-md-5">
                                 <div class="image-cta-service">
-                                    <img src="./assets/images/service/cta-list3.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/service/cta-list3.jpg') }}" alt="image">
                                     <div class="quote-feature-wrap">
                                         <div class="counter  tf-counters">
                                             <div class="numbers number-style" data-speed="2000" data-to="25"

--- a/templates/team-details.html
+++ b/templates/team-details.html
@@ -247,14 +247,14 @@
                                     patience, and the passion to reach " </p>
                                 <div class="flex-three name">
                                     <span>--- Harriet Tubman</span>
-                                    <img src="./assets/images/testimonial/name.png" alt="image">
+                                    <img src="{{ url_for('static', filename='images/testimonial/name.png') }}" alt="image">
                                 </div>
 
                             </div>
                         </div>
                         <div class="row">
                             <div class="col-lg-12">
-                                <img src="./assets/images/team/team-single.jpg" alt="image">
+                                <img src="{{ url_for('static', filename='images/team/team-single.jpg') }}" alt="image">
                             </div>
                         </div>
                         <div class="row">
@@ -389,7 +389,7 @@
                                                                 <span class="date-skill">2022</span>
                                                             </div>
                                                             <p class="browser">Best designer awards</p>  
-                                                            <div class="team-hover" style="background-image: url('./assets/images/team/team-hover.jpg');"></div>                                                 
+                                                            <div class="team-hover" style="background-image: url('{{ url_for('static', filename='images/team/team-hover.jpg') }}');"></div>                                                 
                                                         </div>
                                                         <div class="awards-item bb-blog hover-images">
                                                             <div class="flex-two">
@@ -397,7 +397,7 @@
                                                                 <span class="date-skill">2020</span>
                                                             </div>
                                                             <p class="browser">Best designer awards</p> 
-                                                            <div class="team-hover" style="background-image: url('./assets/images/team/team-hover.jpg');"></div>                                                    
+                                                            <div class="team-hover" style="background-image: url('{{ url_for('static', filename='images/team/team-hover.jpg') }}');"></div>                                                    
                                                         </div>
                                                         <div class="awards-item bb-blog hover-images" >
                                                             <div class="flex-two">
@@ -405,7 +405,7 @@
                                                                 <span class="date-skill">2018</span>
                                                             </div>
                                                             <p class="browser">Best designer awards</p> 
-                                                            <div class="team-hover" style="background-image: url('./assets/images/team/team-hover.jpg');"></div>                                                    
+                                                            <div class="team-hover" style="background-image: url('{{ url_for('static', filename='images/team/team-hover.jpg') }}');"></div>                                                    
                                                         </div>
                                                         <div class="awards-item bb-blog hover-images">
                                                             <div class="flex-two">
@@ -413,7 +413,7 @@
                                                                 <span class="date-skill">2016</span>
                                                             </div>
                                                             <p class="browser">Best designer awards</p>  
-                                                            <div class="team-hover" style="background-image: url('./assets/images/team/team-hover.jpg');"></div>                                                   
+                                                            <div class="team-hover" style="background-image: url('{{ url_for('static', filename='images/team/team-hover.jpg') }}');"></div>                                                   
                                                         </div>
                                                     </div>
                                                     
@@ -426,68 +426,68 @@
                                         <div class="swiper brand-logo2 overflow-hiden mb-40">
                                                 <div class="swiper-wrapper">
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br1.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br1.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br2.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br2.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br3.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br3.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br4.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br4.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br5.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br5.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br6.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br6.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br7.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br7.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br8.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br8.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br9.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br9.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br10.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br10.png') }}" alt="image">
                                                     </div>
                                                 </div>
                                         </div>
                                         <div class="swiper brand-logo2 overflow-hiden">
                                                 <div class="swiper-wrapper">
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br5.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br5.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br6.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br6.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br7.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br7.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br8.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br8.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br9.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br9.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br10.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br10.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br1.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br1.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br2.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br2.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br3.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br3.png') }}" alt="image">
                                                     </div>
                                                     <div class="swiper-slide">
-                                                        <img src="./assets/images/brand/br4.png" alt="image">
+                                                        <img src="{{ url_for('static', filename='images/brand/br4.png') }}" alt="image">
                                                     </div>
                                                     
                                                 </div>

--- a/templates/team.html
+++ b/templates/team.html
@@ -300,12 +300,12 @@
                             </div>
                             <div class="col-12 col-sm-6 col-lg-4">
                                 <div class="skill-team-image-center">
-                                    <img src="./assets/images/team/team-skill.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/team/team-skill.jpg') }}" alt="image">
                                 </div>
                             </div>
                             <div class="col-12 col-sm-6 col-lg-3">
                                 <div class="skill-team-image-right">
-                                    <img src="./assets/images/team/team-skill1.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/team/team-skill1.jpg') }}" alt="image">
                                 </div>
                             </div>
                         </div>
@@ -373,7 +373,7 @@
                                     </div>
                                     <div class="image relative">
                                         <a href="team-details.html">
-                                            <img src="./assets/images/team/team1.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/team1.jpg') }}" alt="image">
                                         </a>
                                         <ul class="social-team flex-five">
                                             <li>
@@ -402,7 +402,7 @@
                                     </div>
                                     <div class="image relative">
                                         <a href="team-details.html">
-                                            <img src="./assets/images/team/team2.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/team2.jpg') }}" alt="image">
                                         </a>
                                         <ul class="social-team flex-five">
                                             <li>
@@ -431,7 +431,7 @@
                                     </div>
                                     <div class="image relative">
                                         <a href="team-details.html">
-                                            <img src="./assets/images/team/team3.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/team3.jpg') }}" alt="image">
                                         </a>
                                         <ul class="social-team flex-five">
                                             <li>
@@ -460,7 +460,7 @@
                                     </div>
                                     <div class="image relative">
                                         <a href="team-details.html">
-                                            <img src="./assets/images/team/team4.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/team4.jpg') }}" alt="image">
                                         </a>
                                         <ul class="social-team flex-five">
                                             <li>
@@ -489,7 +489,7 @@
                                     </div>
                                     <div class="image relative">
                                         <a href="team-details.html">
-                                            <img src="./assets/images/team/team5.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/team5.jpg') }}" alt="image">
                                         </a>
                                         <ul class="social-team flex-five">
                                             <li>
@@ -518,7 +518,7 @@
                                     </div>
                                     <div class="image relative">
                                         <a href="team-details.html">
-                                            <img src="./assets/images/team/team6.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/team6.jpg') }}" alt="image">
                                         </a>
                                         <ul class="social-team flex-five">
                                             <li>
@@ -547,7 +547,7 @@
                                     </div>
                                     <div class="image relative">
                                         <a href="team-details.html">
-                                            <img src="./assets/images/team/team7.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/team7.jpg') }}" alt="image">
                                         </a>
                                         <ul class="social-team flex-five">
                                             <li>
@@ -576,7 +576,7 @@
                                     </div>
                                     <div class="image relative">
                                         <a href="team-details.html">
-                                            <img src="./assets/images/team/team8.jpg" alt="image">
+                                            <img src="{{ url_for('static', filename='images/team/team8.jpg') }}" alt="image">
                                         </a>
                                         <ul class="social-team flex-five">
                                             <li>
@@ -739,7 +739,7 @@
                             </div>
                             <div class="col-md-5">
                                 <div class="image-faq-team">
-                                    <img src="./assets/images/team/team-faq.jpg" alt="image">
+                                    <img src="{{ url_for('static', filename='images/team/team-faq.jpg') }}" alt="image">
                                 </div>
 
                             </div>


### PR DESCRIPTION
## Summary
- update image sources across templates to use `url_for` with the `static` directory
- ensure background-image URLs also reference static assets

## Testing
- `python -m py_compile app.py dbase.py`

------
https://chatgpt.com/codex/tasks/task_e_6854b4d847e88322aed93912514f4ff8